### PR TITLE
COM-3560: Change to accept custom headers from API calls

### DIFF
--- a/Mozu.Api.Test/Helpers/ServiceClientMessageFactory.cs
+++ b/Mozu.Api.Test/Helpers/ServiceClientMessageFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http.Headers;
+using System.Collections.Generic;
 
 namespace Mozu.Api.Test.Helpers
 {
@@ -74,6 +75,18 @@ namespace Mozu.Api.Test.Helpers
             var msgHandler = new ServiceClientMessageHandler(apiContext);
             return msgHandler;
         }
+        /// <summary>
+        /// This is a sample of how to quickly generate a ApiContext with tenantId and custom headers
+        /// </summary>
+        /// <param name="tenantId"></param>
+        /// <param name="customHeaders"></param>
+        /// <returns></returns>
+        public static ServiceClientMessageHandler GetTestClientMessage(int tenantId = 0, IDictionary<string, string> customHeaders = null)
+        {
+            var apiContext = new ApiContext(tenantId: tenantId, customHeaders: customHeaders);
+            var msgHandler = new ServiceClientMessageHandler(apiContext);
+            return msgHandler;
+        }
 
         /// <summary>
         /// This is a sample of how to quickly generate a ApiContext with data only for the site the user is shopping in the MessageHandler's correct http header.
@@ -87,6 +100,8 @@ namespace Mozu.Api.Test.Helpers
             var msgHandler = new ServiceClientMessageHandler(apiContext);
             return msgHandler;
         }
+
+       
 
     }
 

--- a/Mozu.Api.Test/Mozu.Api.Test.csproj
+++ b/Mozu.Api.Test/Mozu.Api.Test.csproj
@@ -91,6 +91,7 @@
     <Compile Include="MsTestCases\AppAuthTest.cs" />
     <Compile Include="MsTestCases\CategoryTests.cs" />
     <Compile Include="MsTestCases\CustomerTests.cs" />
+    <Compile Include="MsTestCases\CustomHeaderTest.cs" />
     <Compile Include="MsTestCases\DocumentTest.cs" />
     <Compile Include="MsTestCases\OrderTests.cs" />
     <Compile Include="MsTestCases\ProductAttributeTests.cs" />

--- a/Mozu.Api.Test/MsTestCases/CustomHeaderTest.cs
+++ b/Mozu.Api.Test/MsTestCases/CustomHeaderTest.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mozu.Api.Test.Helpers;
+using System;
+using System.Collections.Generic;
+
+namespace Mozu.Api.Test.MsTestCases
+{
+    [TestClass]
+    public class CustomHeaderTest: BaseDataFactory
+    {
+        int tenantId = 0;
+
+        [TestInitialize]
+        public void TestMethodInit()
+        {
+            tenantId = Convert.ToInt32(Mozu.Api.Test.Helpers.Environment.GetConfigValueByEnvironment("TenantId"));
+        }
+
+        [TestMethod]
+        [Description("Custom Headers test")]
+        public void Http_Request_Contains_Custom_Header()
+        {
+            var customHeaders = new Dictionary<string, string>()
+            {
+                {"x-vol-cluster","unified" }
+            };
+            var baseUrlAddress = Helpers.Environment.GetConfigValueByEnvironment(Environment, "BaseAuthAppUrl");
+            SetSdKparameters();
+            var ApiMsgHandler = ServiceClientMessageFactory.GetTestClientMessage(tenantId, customHeaders);
+            var client = Mozu.Api.Clients.Commerce.Catalog.Admin.ProductClient.GetProductClient(DataViewMode.Live, "test").WithBaseAddress(baseUrlAddress);
+            var request = client.WithContext(ApiMsgHandler.ApiContext).RequestMessage;
+
+            Assert.IsTrue(request.Headers.Contains("x-vol-cluster"));
+        }
+
+        [TestMethod]
+        [Description("Cloning ApiContext with custom headers")]
+        public void Clone_ApiContext_With_Custom_Header()
+        {
+            var customHeaders = new Dictionary<string, string>()
+            {
+                {"x-vol-cluster","unified" }
+            };
+            var ApiMsgHandler = ServiceClientMessageFactory.GetTestClientMessage(tenantId,null);
+            var cloneApiContext = ApiMsgHandler.ApiContext.CloneWith(x => x.CustomHeaders = customHeaders);
+
+            Assert.IsTrue(cloneApiContext.CustomHeaders.ContainsKey("x-vol-cluster"));
+        }
+
+        [TestMethod]
+        [Description("ApiContext does not change upon editing its clone")]
+        public void ApiContext_does_not_change_upon_editing_its_clone()
+        {
+            var customHeaders = new Dictionary<string, string>()
+            {
+                {"x-vol-cluster","unified" }
+            };
+            var ApiMsgHandler = ServiceClientMessageFactory.GetTestClientMessage(tenantId, null);
+            var cloneApiContext = ApiMsgHandler.ApiContext.CloneWith(x => x.CustomHeaders = customHeaders);
+
+            Assert.IsTrue(ApiMsgHandler.ApiContext.CustomHeaders == null);
+        }
+
+    }
+}

--- a/Mozu.Api/ApiContext.cs
+++ b/Mozu.Api/ApiContext.cs
@@ -36,8 +36,9 @@ namespace Mozu.Api
         string BypassCache { get; set; }
         string Pricelist { get; set; }
         string PreviewDate { get; set; }
+		IDictionary<string,string> CustomHeaders { get; set; }
 
-    IApiContext CloneWith(Action<IApiContext> contextModification);
+	IApiContext CloneWith(Action<IApiContext> contextModification);
 	}
 
     [Serializable]
@@ -66,28 +67,31 @@ namespace Mozu.Api
         public string BypassCache { get; set; }
         public string Pricelist { get; set; }
         public string PreviewDate { get; set; }
+		public IDictionary<string, string> CustomHeaders { get; set; }
 
-        public ApiContext()
+	public ApiContext()
 		{
 		}
 
-		public ApiContext(int tenantId, int? siteId = null, int? masterCatalogId = null, int? catalogId = null)
+		public ApiContext(int tenantId, int? siteId = null, int? masterCatalogId = null, int? catalogId = null,IDictionary<string,string> customHeaders = null)
 		{
 			TenantId = tenantId;
 			SiteId = siteId;
 			MasterCatalogId = masterCatalogId;
 			CatalogId = catalogId;
+		    CustomHeaders = customHeaders;
 		}
 
-		public ApiContext(Tenant tenant, Site site = null, int? masterCatalogId = null, int? catalogId = null)
+		public ApiContext(Tenant tenant, Site site = null, int? masterCatalogId = null, int? catalogId = null, IDictionary<string, string> customHeaders = null)
 		{
             Tenant = tenant;
 			TenantId = tenant.Id;
 			TenantUrl = tenant.Domain;
 			MasterCatalogId = masterCatalogId;
 			CatalogId = catalogId;
+			CustomHeaders = customHeaders;
 
-            SetBySite(site);
+			SetBySite(site);
 
             if (!masterCatalogId.HasValue && Tenant.MasterCatalogs.Count == 1)
             {
@@ -98,12 +102,13 @@ namespace Mozu.Api
 
         }
 
-		public ApiContext(Site site, int? masterCatalogId = null, int? catalogId = null)
+		public ApiContext(Site site, int? masterCatalogId = null, int? catalogId = null, IDictionary<string, string> customHeaders = null)
 		{
 			TenantId = site.TenantId;
 			MasterCatalogId = masterCatalogId;
 			CatalogId = catalogId;
-		    SetBySite(site);
+			CustomHeaders = customHeaders;
+			SetBySite(site);
 
 		}
 
@@ -212,7 +217,8 @@ namespace Mozu.Api
                 NoCacheUpdate = (!String.IsNullOrEmpty(this.NoCacheUpdate) ? (string)this.NoCacheUpdate.Clone() : null),
                 BypassCache = (!String.IsNullOrEmpty(this.BypassCache) ? (string)this.BypassCache.Clone() : null),
                 Pricelist = (!String.IsNullOrEmpty(this.Pricelist) ? (string)this.Pricelist.Clone() : null),
-                PreviewDate = (!String.IsNullOrEmpty(this.PreviewDate) ? (string)this.PreviewDate.Clone() : null)
+                PreviewDate = (!String.IsNullOrEmpty(this.PreviewDate) ? (string)this.PreviewDate.Clone() : null),
+				CustomHeaders= (this.CustomHeaders != null) ? (new Dictionary<string,string>(this.CustomHeaders)) : null
             };
 
 			contextModification(cloned);

--- a/Mozu.Api/MozuClient.cs
+++ b/Mozu.Api/MozuClient.cs
@@ -236,6 +236,8 @@ namespace Mozu.Api
                 if (_apiContext != null && !String.IsNullOrEmpty(_apiContext.CorrelationId))
                     AddHeader(Headers.X_VOL_CORRELATION, _apiContext.CorrelationId);
 
+                
+
                 foreach (var key in _headers.AllKeys)
                 {
                     client.DefaultRequestHeaders.Add(key, _headers[key]);
@@ -309,7 +311,16 @@ namespace Mozu.Api
 
             if (!string.IsNullOrEmpty(_apiContext.Currency))
                 AddHeader(Headers.X_VOL_CURRENCY, _apiContext.Currency);
-		}
+
+            //Adding the custom headers to namevaluecollection.
+            if (_apiContext.CustomHeaders != null)
+            {
+                foreach (var header in _apiContext.CustomHeaders)
+                {
+                    AddHeader(header.Key, header.Value);
+                }
+            }
+        }
 
         protected void SetBaseAddress(string baseAddress)
         {


### PR DESCRIPTION
Added a new property customHeaders to apiContext to send in the custom headers. These headers will be added to existing headers during api calls.